### PR TITLE
Add global .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# This is a global gitignore to complement the gitignore which is specifically in the Software directory.
+
+# DS_Store files are created by Mac OS X Finder
+.DS_Store

--- a/Software/LMSourceCode/.gitignore
+++ b/Software/LMSourceCode/.gitignore
@@ -361,6 +361,3 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-
-# DS_Store files
-.DS_Store


### PR DESCRIPTION
I attempted to add a `.DS_Store` supression line to the `.gitignore` and it wasn't fully working as expected — but then realized that it's only scoped to that directory.

In order to solve this particular issue (annoying auto-generated Mac files) we need a global `.gitignore` as well, so I moved the `.DS_Store` line to that file.