### PR TITLE
Move .DS_Store to global .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .vscode/
 # Ignoring ~/build inside LMSourceCode
 /Software/LMSourceCode/ImageProcessing/build
+
+# .DS_Store files are created by Mac OS X Finder
+.DS_Store

--- a/Software/LMSourceCode/.gitignore
+++ b/Software/LMSourceCode/.gitignore
@@ -361,6 +361,3 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
-
-# DS_Store files
-.DS_Store


### PR DESCRIPTION
The `.DS_Store` file ignoring is relevant throughout the repo.