### PR TITLE
feat: removing bcm legacy support for detection

### DIFF
--- a/Software/LMSourceCode/ImageProcessing/gs_config.cpp
+++ b/Software/LMSourceCode/ImageProcessing/gs_config.cpp
@@ -4,12 +4,13 @@
  */
 
 #ifdef __unix__  // Ignore in Windows environment
-#include <bcm_host.h>
 #endif
 #include <boost/foreach.hpp>
 #include <cstdlib>
 #include <memory>
-
+#include <fstream>
+#include <string>
+#include <sstream>
 #include "logging_tools.h"
 #include "gs_camera.h"
 #include "gs_ui_system.h"
@@ -104,35 +105,34 @@ namespace golf_sim {
 
 	// TBD - Will need to be improved to adapt to having two cameras on the same
 	// Pi.
-	GolfSimConfiguration::PiModel GolfSimConfiguration::GetPiModel() {
-		GolfSimConfiguration::PiModel pi_model  = kRPi5;
+GolfSimConfiguration::PiModel GolfSimConfiguration::GetPiModel() {
+    GolfSimConfiguration::PiModel pi_model = kRPi5;
 
-#ifdef __unix__  // Ignore in Windows environment
-		int processor_type = bcm_host_get_processor_id();
+#ifdef __unix__
+    std::ifstream cpuinfo("/proc/cpuinfo");
+    std::string line;
+    std::string hardware;
 
-		GS_LOG_TRACE_MSG(trace, "GolfSimConfiguration - bcm_host_get_processor_id returned:" + std::to_string(processor_type));
+    while (std::getline(cpuinfo, line)) {
+        if (line.find("Hardware") != std::string::npos || line.find("Model") != std::string::npos) {
+            hardware = line;
+            break;
+        }
+    }
 
-		switch (processor_type) {
-			/** NOT IMPLEMENTED YET 
-			case BCM_HOST_PROCESSOR_BCM2712:
-				pi_model = kRPi5;
-				break;
-			**/
-			case BCM_HOST_PROCESSOR_BCM2837:
-				pi_model = kRPi5;
-				break;
+    GS_LOG_TRACE_MSG(trace, "GolfSimConfiguration - CPU Info line: " + hardware);
 
-			case BCM_HOST_PROCESSOR_BCM2711:
-					pi_model = kRPi4;
-					break;
+    if (hardware.find("BCM2711") != std::string::npos || hardware.find("Raspberry Pi 4") != std::string::npos) {
+        pi_model = kRPi4;
+    } else if (hardware.find("BCM2837") != std::string::npos || hardware.find("Raspberry Pi 3") != std::string::npos) {
+        pi_model = kRPi5; // or kRPi3 if you support that specifically
+    } else if (hardware.find("BCM2712") != std::string::npos || hardware.find("Raspberry Pi 5") != std::string::npos) {
+        pi_model = kRPi5;
+    }
+#endif
 
-			default:
-				pi_model = kRPi5;
-				break;
-		}
-#endif	
-		return pi_model;
-	}
+    return pi_model;
+}
 
 
 bool GolfSimConfiguration::ReadValues() {

--- a/Software/LMSourceCode/ImageProcessing/gs_config.cpp
+++ b/Software/LMSourceCode/ImageProcessing/gs_config.cpp
@@ -122,20 +122,6 @@ GolfSimConfiguration::PiModel GolfSimConfiguration::GetPiModel() {
             break;
         }
 
-        // Optionally check revision code if 'Model' is not found
-        if (line.find("Revision") != std::string::npos) {
-            std::string rev = line.substr(line.find(":") + 1);
-            rev.erase(std::remove_if(rev.begin(), rev.end(), ::isspace), rev.end());
-
-            // Use revision codes if needed (optional and extensible)
-            if (rev == "a020d3" || rev == "a03111") {
-                pi_model = kRPi3;
-            } else if (rev == "b03111" || rev == "c03111") {
-                pi_model = kRPi4;
-            } else if (rev == "10050000" || rev == "10050001") {
-                pi_model = kRPi5;
-            }
-        }
     }
 
     return pi_model;

--- a/Software/LMSourceCode/ImageProcessing/meson.build
+++ b/Software/LMSourceCode/ImageProcessing/meson.build
@@ -51,7 +51,6 @@ endif
 ssl_dep = dependency('openssl', required : true)
 activemq_dep = dependency('activemq-cpp', required : true)
 apr_dep = cxx.find_library('apr-1', required : true)
-bcm_host_dep = cxx.find_library('bcm_host', required : true)
 
 libcamera_dep = dependency('libcamera', required : true)
 thread_dep = dependency('threads', required : true)
@@ -70,7 +69,7 @@ rpicam_app_dep = [libcamera_dep, lgpio_dep]
 
 pitrac_lm_module_deps = [
 	libcamera_dep, thread_dep, opencv_dep, lgpio_dep, rpicam_app_dep, 
-	fmt_dep, boost_dep, activemq_dep, ssl_dep, apr_dep, bcm_host_dep, msgpack_dep,]
+	fmt_dep, boost_dep, activemq_dep, ssl_dep, apr_dep, msgpack_dep,]
 
 
 


### PR DESCRIPTION
Appears that the desktop has deprecated BCM support. This issue will rise when users update their libraries. 

**Needs full testing with this code before merging.** 

- Removing bcm_host support due to raspberrypi-ui-mod removing support. 
- Replace the whole bcm_host_get_processor_id() block with a std::ifstream read to parse /proc/cpuinfo.
- When installing libraspberrypi-dev to add bcm_host, it then removes the desktop.

<img width="819" height="358" alt="image" src="https://github.com/user-attachments/assets/d867ca8e-b140-4f54-aad5-af1b31716d0a" />
