### PR TITLE
docs: fixed boot order, update name.

### DIFF
--- a/Dev/assets/vimrc
+++ b/Dev/assets/vimrc
@@ -1,0 +1,56 @@
+" Enable line numbers
+set number
+
+" Relative line numbers (optional, good for navigation)
+" set relativenumber
+
+" Highlight current line
+set cursorline
+
+" Enable syntax highlighting
+syntax on
+
+" Better search
+set ignorecase        " Ignore case when searching...
+set smartcase         " ...unless search has capital letters
+set hlsearch          " Highlight search matches
+set incsearch         " Show matches as you type
+
+" Indentation settings
+set tabstop=4         " Number of spaces that a <Tab> counts for
+set shiftwidth=4      " Number of spaces for each step of (auto)indent
+set expandtab         " Use spaces instead of tabs
+set autoindent        " Auto-indent new lines
+set smartindent       " Smarter indentation
+
+" Show matching brackets
+set showmatch
+
+" Enable mouse support
+set mouse=a
+
+" Show line and column number in status bar
+set ruler
+
+" Always show status line
+set laststatus=2
+
+" Enable filetype plugins and indentation
+filetype plugin indent on
+
+" Remember last position in file
+augroup resume_cursor
+    autocmd!
+    autocmd BufReadPost * if line("'\"") > 0 && line("'\"") <= line("$") | exe "normal! g`\"" | endif
+augroup END
+
+" Show invisible characters (tabs, trailing spaces)
+set list
+set listchars=tab:?\ ,trail:Â·
+
+" Better command-line completion
+set wildmenu
+set wildmode=longest:full,full
+
+" Allow backspacing over everything in insert mode
+set backspace=indent,eol,start

--- a/Dev/run.sh
+++ b/Dev/run.sh
@@ -6,6 +6,20 @@ if [ -z "$BASH_VERSION" ]; then
   exit 1
 fi
 
+
+install_vim() {
+# Check if vim is installed
+ if ! command -v vim >/dev/null 2>&1; then
+    echo "Vim not found. Installing..."
+    sudo apt-get update && sudo apt-get install -y vim
+
+    echo "Move vimrc config file to user path"
+    cp assets/vimrc ~/.vimrc
+ fi
+}
+
+
+
 # Install 'dialog' if not already installed (apt-get only)
 install_dialog_if_missing() {
   if ! command -v dialog >/dev/null 2>&1; then
@@ -27,6 +41,7 @@ check_internet_connectivity() {
 
 check_internet_connectivity
 install_dialog_if_missing
+install_vim
 
 
 
@@ -68,7 +83,9 @@ done
 
 verify_boost_install() {
 
-sudo apt-get install libboost1.74-all
+sudo apt-get update
+
+sudo apt -y install libboost1.74-all-dev
 
 BOOST_MIN_VERSION="1.74"
 BOOST_VERSION_RAW=$(grep "BOOST_LIB_VERSION" /usr/include/boost/version.hpp | cut -d '"' -f2)
@@ -108,9 +125,9 @@ MAIN_OPTIONS=(
 INSTALL_OPTIONS=(
   1 "Active MQ Broker 6.1.7"
   2 "Active MQ C++ CMS"
-  3 "MSGPack"
+  3 "Boost 1.74"
   4 "OpenCV 4-11-0"
-  5 "Boost 1.74"
+  5 "MSGPack"
   6 "LGPIO"
   7 "Libcamera 0.5.1 and RpiCam Apps 1.5.3"
   8 "Java 17 OpenJDK"
@@ -186,16 +203,16 @@ show_install_menu() {
           bash ./scripts/install_activemq_cpp_cms.sh
           ;;
         3)
-          echo "Installing MSGPack..."
-          bash ./scripts/install_msgpack.sh 
+          echo "Installing Boost..."
+          verify_boost_install
           ;;
         4) 
           echo "Installing OpenCV 4-11-0..."
           bash ./scripts/install_opencv.sh
           ;;
         5)
-          echo "Installing Boost..."
-          verify_boost_install
+          echo "Installing MSGPack..."
+          bash ./scripts/install_msgpack.sh
           ;;
           6) 
           echo "Installing LGPIO..."

--- a/Dev/scripts/install_msgpack.sh
+++ b/Dev/scripts/install_msgpack.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+
+# Install required libraries
+sudo apt -y install cmake
+
+
+
 echo "Cloning msgpack..."
 wget https://github.com/msgpack/msgpack-c/archive/refs/heads/cpp_master.zip
 unzip cpp_master.zip -d work_dir


### PR DESCRIPTION
- install vim part of run.sh, also vimrc settings.
- update run.sh menu bash script from install_msg-pack.sh to install_msgpack.sh
- cmake is missing from install_msgpack
- msgpack requires boost to be installed first. Changed order.
- libboost1.74-all correction to libboost1.74-all-dev, fails otherwise.