### PR TITLE
patch: remove $ signs on vim edit files. Comes from set list

### DIFF
--- a/Dev/assets/vimrc
+++ b/Dev/assets/vimrc
@@ -44,13 +44,10 @@ augroup resume_cursor
     autocmd BufReadPost * if line("'\"") > 0 && line("'\"") <= line("$") | exe "normal! g`\"" | endif
 augroup END
 
-" Show invisible characters (tabs, trailing spaces)
-set list
-set listchars=tab:?\ ,trail:Â·
-
 " Better command-line completion
 set wildmenu
 set wildmode=longest:full,full
+
 
 " Allow backspacing over everything in insert mode
 set backspace=indent,eol,start


### PR DESCRIPTION
* Was causing issues even opening .bashrc 
* Was displaying $ dollar symbols on blank spaces and trailing spaces. 