### PR TITLE
Codeowners Updates and CLA Migration 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,4 +24,4 @@
 /packaging @connorgallopo
 
 # GitHub Workflows
-.github/workflows @jamespilgrim @connorgallopo
+.github/workflows @jamespilgrim @connorgallopo @jeshernandez

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,27 @@
 # Default owner of the ship. Not needed, but just adding. 
 * @jamespilgrim
 
+/Software @jamespilgrim
+
 # Java Ownership files 
-/Software/LMSourceCode/ImageProcessing/golfsim_tomee_webapp @jeshernandez 
+/Software/LMSourceCode/ImageProcessing/golfsim_tomee_webapp @jeshernandez
+
+# Yolo Model + Tooling
+/Software/GroundTruthAnnotator @connorgallopo
+/Software/LMSourceCode/ImageProcessing @jamespilgrim @connorgallopo
 
 # Documentation files
-/docs @jeshernandez
+/docs @jeshernandez @connorgallopo
+/docs/hardware @markjonharman
 
 # Installation Scripts
-
 /Dev @jeshernandez
+
+# Hardware
+/Hardware @markjonharman
+
+# Packaging
+/packaging @connorgallopo
+
+# GitHub Workflows
+.github/workflows @jamespilgrim @connorgallopo

--- a/.github/workflows/camera-tests.yml
+++ b/.github/workflows/camera-tests.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - "**"
+    paths:
+      - 'Software/LMSourceCode/ImageProcessing/Camera/**'
+      - '.github/workflows/camera-tests.yml'
   pull_request:
     branches:
       - "**"
+    paths:
+      - 'Software/LMSourceCode/ImageProcessing/Camera/**'
+      - '.github/workflows/camera-tests.yml'
 env:
   BOOST_VERSION: 1.84.0
   BOOST_MSVC_VERSION: "14.3"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,6 +19,11 @@ concurrency:
 jobs:
   cla-assistant:
     runs-on: ubuntu-latest
+ 
+    env:
+      SIGNATURE_PHRASE: "I have read the CLA Document and I hereby sign the CLA"
+      RECHECK_PHRASE: "recheck"
+
     steps:
       - name: "CLA Assistant"
         if: >
@@ -43,5 +48,26 @@ jobs:
           allowlist: "dependabot[bot],github-actions[bot]"
 
           # lock-pullrequest-aftermerge: true
-          # suggest-recheck: true
 
+          create-file-commit-message: "Create signatures store"
+          signed-commit-message: "$contributorName has signed the CLA in $owner/$repo#$pullRequestNo"
+
+          custom-notsigned-prcomment: |
+            Thanks for your PR! Before we can review it, please sign our Contributor License Agreement.
+
+            **How to sign (right here in this PR):**
+            1. Read the CLA: $pathToCLADocument
+            2. Add a new PR comment with exactly this line (copy & paste):
+               ```
+               ${{ env.SIGNATURE_PHRASE }}
+               ```
+            3. Already signed and not seeing the check pass? Ask me to recheck by commenting:
+               ```
+               ${{ env.RECHECK_PHRASE }}
+               ```
+
+          custom-pr-sign-comment: ${{ env.SIGNATURE_PHRASE }}
+
+          custom-allsigned-prcomment: "All contributors have signed the CLA. Thanks!"
+
+          suggest-recheck: true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,44 +1,47 @@
 ---
 name: "CLA Assistant"
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [opened, synchronize, reopened, closed]
 
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
 permissions:
-  actions: write
-  contents: write # this can be 'read' if the signatures are in remote repository
+  contents: read
   pull-requests: write
   statuses: write
 
+concurrency:
+  group: cla-assistant-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  CLAAssistant:
+  cla-assistant:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        if: >
+          github.event_name == 'pull_request_target' ||
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+        uses: contributor-assistant/github-action@2.6.1
         env:
+          # Built-in token for commenting on the PR and setting statuses in PiTrac
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          # This token is required only if you have configured to store the signatures in a remote repository/organization
-          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          # Fine-grained / classic PAT that can write to PitracCLASignatures
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://gist.github.com/jamespilgrim/e6996a438adc0919ebbe70561efbb600#file-verdant-contributor-license-agreement-md' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          allowlist: bot*
+          path-to-document: "https://gist.github.com/jamespilgrim/e6996a438adc0919ebbe70561efbb600#file-verdant-contributor-license-agreement-md"
+          path-to-signatures: "signatures/version1/cla.json"
 
-         # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
-          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
-          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
-          #use-dco-flag: true - If you are using DCO instead of CLA
+          remote-organization-name: "jamespilgrim"
+          remote-repository-name: "PitracCLASignatures"
+
+          branch: "main"
+
+          allowlist: "dependabot[bot],github-actions[bot]"
+
+          # lock-pullrequest-aftermerge: true
+          # suggest-recheck: true
+

--- a/.github/workflows/image-analysis-tests.yml
+++ b/.github/workflows/image-analysis-tests.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - "**"
+    paths:
+      - 'Software/LMSourceCode/ImageProcessing/ImageAnalysis/**'
+      - '.github/workflows/image-analysis-tests.yml'
   pull_request:
     branches:
       - "**"
+    paths:
+      - 'Software/LMSourceCode/ImageProcessing/ImageAnalysis/**'
+      - '.github/workflows/image-analysis-tests.yml'
 env:
   BOOST_VERSION: 1.87.0
   BOOST_ROOT: C:\Dev_Env\boost\boost


### PR DESCRIPTION
# What is it?
This PR updates codeowners to help spread the load of merge requests moving forward.

We also moved CLA signatures to an external repository to improve the reliability and circumvent the issues caused by our branch protection rules here.