### PR TITLE
CODEOWNERS fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,26 +1,27 @@
 # Default owner of the ship. Not needed, but just adding. 
 * @jamespilgrim
 
-/Software @jamespilgrim
+/Software/ @jamespilgrim
 
 # Java Ownership files 
-/Software/LMSourceCode/ImageProcessing/golfsim_tomee_webapp @jeshernandez
+/Software/LMSourceCode/ImageProcessing/golfsim_tomee_webapp/ @jeshernandez 
 
 # Yolo Model + Tooling
-/Software/GroundTruthAnnotator @connorgallopo
-/Software/LMSourceCode/ImageProcessing @jamespilgrim @connorgallopo
+/Software/GroundTruthAnnotator/ @connorgallopo
+/Software/LMSourceCode/ImageProcessing/ @jamespilgrim @connorgallopo
 
 # Documentation files
-/docs @jeshernandez @connorgallopo @markjonharman
+/docs/ @jeshernandez @connorgallopo
+/docs/hardware/ @markjonharman
 
 # Installation Scripts
-/Dev @jeshernandez
+/Dev/ @jeshernandez @connorgallopo
 
 # Hardware
-/Hardware @markjonharman
+/Hardware/ @markjonharman
 
 # Packaging
-/packaging @connorgallopo
+/packaging/ @connorgallopo
 
 # GitHub Workflows
-.github/workflows @jamespilgrim @connorgallopo @jeshernandez @markjonharman
+/.github/workflows/ @jamespilgrim @connorgallopo @jeshernandez

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,11 @@
 # Default owner of the ship. Not needed, but just adding. 
 * @jamespilgrim
+/.github/workflows/CODEOWNERS @jamespilgrim
 
+# GitHub Workflows
+/.github/workflows/ @jamespilgrim @connorgallopo @jeshernandez
+
+# Top Level Software Ownership
 /Software/ @jamespilgrim
 
 # Java Ownership files 
@@ -23,5 +28,3 @@
 # Packaging
 /packaging/ @connorgallopo
 
-# GitHub Workflows
-/.github/workflows/ @jamespilgrim @connorgallopo @jeshernandez

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 permissions:
+  actions: write
   contents: read
   pull-requests: write
   statuses: write
@@ -23,13 +24,14 @@ jobs:
     env:
       SIGNATURE_PHRASE: "I have read the CLA Document and I hereby sign the CLA"
       RECHECK_PHRASE: "recheck"
+      PATH_TO-DOCUMENT: "https://gist.github.com/jamespilgrim/e6996a438adc0919ebbe70561efbb600#file-verdant-contributor-license-agreement-md"
 
     steps:
       - name: "CLA Assistant"
         if: >
-          github.event_name == 'pull_request_target' ||
-          github.event.comment.body == 'recheck' ||
-          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          (github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           # Built-in token for commenting on the PR and setting statuses in PiTrac
@@ -56,7 +58,7 @@ jobs:
             Thanks for your PR! Before we can review it, please sign our Contributor License Agreement.
 
             **How to sign (right here in this PR):**
-            1. Read the CLA: $pathToCLADocument
+            1. Read the CLA: ${{ env.PATH_TO_DOCUMENT }}
             2. Add a new PR comment with exactly this line (copy & paste):
                ```
                ${{ env.SIGNATURE_PHRASE }}


### PR DESCRIPTION
## Summary
This is a final fix of CODEOWNERS. We still have some permissions to iron out, but the biggest issue we had was syntax and a misunderstanding of how certain things are handled.

### Examples
So lets take something like: `/Hardware @markjonharman`
- Matches the `Hardware` path itself (could be a file or a folder), but does NOT include all it's contents.
Rewritten as: `Hardware/ @markjonharman`
- Matches the `Hardware` directory AND all subdirectories and files

### Further Changes
For some "good repo safety" I added @jamespilgrim as the EXPLICIT owner of the CODEOWNERS file. This makes sure that nobody is allowed to do something like change the codeowners file on their own to gain larger scope without explicit consent from the repo owner.

