### PR TITLE
Added kernel overlays for single-pi operation (2 cameras on one pi)

### DIFF
--- a/packaging/src/boot/config.sh
+++ b/packaging/src/boot/config.sh
@@ -24,6 +24,14 @@ if needs_gpu_memory_setting "$model"; then
   echo "  gpu_mem=$(get_recommended_gpu_memory)"
 fi
 
+if is_single_pi ; then
+  echo "  # Setup camera on slot 0 to be internally triggered, and on slot 1 to be externally triggered"
+  echo "  dtoverlay=imx296,sync-sink=1 "
+  echo "  dtoverlay=imx296,cam0"
+else
+  echo "<no other camera-related parameters need to be set in config.sys>"
+fi
+
 echo ""
 echo "Edit with: sudo nano $config_file"
 echo "Then reboot: sudo reboot"

--- a/packaging/src/lib/hardware.sh
+++ b/packaging/src/lib/hardware.sh
@@ -146,3 +146,17 @@ get_camera_slots() {
     done
   fi
 }
+
+
+# Determines if running on a single pi by determining how many cameras are attached
+# Returns 0 if this is a single-pi setup (with 2 cameras on the same pi) or 1 if not
+is_single_pi() {
+
+    LINE_COUNT=$(rpicam-hello --list 2>/dev/null | grep -E "^\s*[0-9]+ :" | wc -l )
+
+    if [[ $LINE_COUNT == "2" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}

--- a/packaging/src/setup.sh
+++ b/packaging/src/setup.sh
@@ -39,6 +39,14 @@ if needs_gpu_memory_setting "$pi_model"; then
   echo "  gpu_mem=$(get_recommended_gpu_memory)"
 fi
 
+if is_single_pi ; then
+  echo "  # Setup camera on slot 0 to be internally triggered, and on slot 1 to be externally triggered"
+  echo "  dtoverlay=imx296,sync-sink=1 "
+  echo "  dtoverlay=imx296,cam0"
+else
+  echo "<no other camera-related parameters need to be set in config.sys>"
+fi
+
 echo ""
 echo "=== Current Status ==="
 


### PR DESCRIPTION
## Description
This PR checks to see if the system is setup as a "single pi" mode where both cameras are on the same pi.  With these changes, the postinst and pitrac setup code will add the appropriate kernal dtoverlays to the config.txt boot file, or otherwise tell the user to do so.

### What does this PR do?


### Why is this change needed?
Whenever two cameras are on the same pi, there is an issue because one camera wants to be internally triggered, and one externally triggered.  For BOTH Innomaker and "official" Pi cameras, this requires two "dtoverlay" commands in the bootup config.txt file.

### Related Issue(s)
I note that there is some replicated code between the .deb-based (package) processing in our automated setup scripts and the code that is part of the (mostly separate) scripts that are run with "build.sh dev".  Will have to look into that more at some point.

## Changes Made

## Testing Performed

### Test Environment

### Test Results
Am still testing this.  Mostly committing this PR to make sure I still know how to do so. :)

### Test Commands Run

## Performance Impact

## Breaking Changes
## Dependencies

## Hardware Compatibility

## Documentation

## Screenshots/Videos
<!-- If applicable, add screenshots or videos demonstrating the change -->


## Checklist

### Code Quality
- [ ] Code follows existing patterns and conventions
- [ ] No unnecessary comments added
- [ ] Error handling implemented appropriately

### Build & Test
- [ ] Successfully builds with `./packaging/build.sh build`
- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Tested on actual Raspberry Pi hardware (not just CI)

### Submission Requirements
- [ ] Commits squashed if needed (`git rebase -i HEAD~n`)
- [ ] [CLA signed](https://gist.github.com/jamespilgrim/e6996a438adc0919ebbe70561efbb600)
- [ ] PR title follows format: `[PR TYPE] Brief description`
- [ ] Branch is up-to-date with main

## Additional Context
<!-- Any additional information that reviewers should know -->

---
<!-- 
Thank you for contributing to PiTrac! 🏌️ 
Join our Discord for help: https://discord.gg/vGuyAAxXJH
-->