### PR TITLE
Pathing Issues

### DIFF
--- a/Software/web-server/config_manager.py
+++ b/Software/web-server/config_manager.py
@@ -529,8 +529,8 @@ class ConfigurationManager:
         else:
             # Convert to string and expand paths with ~
             str_value = str(value)
-            if "~/" in str_value:
-                str_value = str_value.replace("~", str(Path.home()))
+            if str_value.startswith("~"):
+                str_value = str(Path(str_value).expanduser())
             current[final_key] = str_value
 
     def get_available_models(self) -> Dict[str, str]:

--- a/Software/web-server/configurations.json
+++ b/Software/web-server/configurations.json
@@ -3529,7 +3529,7 @@
     },
     "gs_config.testing.kAutomatedTestSuiteDirectory": {
       "type": "string",
-      "default": "/home/<PiTrac-Username>/Dev/PiTrac/Software/LMSourceCode/Testing/TestSuite_2025_02_07/",
+      "default": "/usr/share/pitrac/test-suites/TestSuite_2025_02_07/",
       "description": "Directory containing test suite images",
       "category": "testing",
       "ui_name": "Test Suite Directory"
@@ -3853,7 +3853,7 @@
     },
     "gs_config.calibration.kTestAutoCalibrationFileName": {
       "type": "string",
-      "default": "M:\\Dev\\PiTrac\\Software\\LMSourceCode\\Images\\autocalibrate_cam1_still_picture_1.png",
+      "default": "/usr/share/pitrac/calibration/checkerboard.png",
       "description": "Test file for auto calibration",
       "category": "calibration",
       "ui_name": "Test Auto Cal File"

--- a/Software/web-server/configurations.json
+++ b/Software/web-server/configurations.json
@@ -825,7 +825,8 @@
       "type": "path",
       "default": "~/LM_Shares/Images/",
       "requiresRestart": false,
-      "passedVia": "json",
+      "passedVia": "cli",
+      "cliArgument": "--base_image_logging_dir",
       "passedTo": "both"
     },
     "gs_config.ipc_interface.kWebServerShareDirectory": {

--- a/packaging/build-apt-package.sh
+++ b/packaging/build-apt-package.sh
@@ -155,8 +155,9 @@ install_binaries() {
 
 install_test_resources() {
     log_info "Installing test images and calibration tools..."
-    
+
     install_test_images "$DEB_DIR/usr/share/pitrac/test-images" "$REPO_ROOT"
+    install_test_suites "$DEB_DIR/usr/share/pitrac/test-suites" "$REPO_ROOT"
     install_camera_tools "$DEB_DIR/usr/lib/pitrac" "$REPO_ROOT"
     
     log_info "Staging ONNX models..."

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -419,7 +419,9 @@ build_dev() {
     install_camera_tools "/usr/lib/pitrac" "$REPO_ROOT"
 
     install_test_images "/usr/share/pitrac/test-images" "$REPO_ROOT"
-    
+
+    install_test_suites "/usr/share/pitrac/test-suites" "$REPO_ROOT"
+
     install_onnx_models "$REPO_ROOT" "${SUDO_USER:-$(whoami)}"
 
     # Install calibration tools

--- a/packaging/src/lib/pitrac-common-functions.sh
+++ b/packaging/src/lib/pitrac-common-functions.sh
@@ -245,13 +245,13 @@ get_install_user() {
 install_test_images() {
     local dest_dir="${1:-/usr/share/pitrac/test-images}"
     local repo_root="${2:-${REPO_ROOT:-/opt/PiTrac}}"
-    
+
     log_info "Installing test images..."
-    
+
     local test_images_dir="$repo_root/Software/LMSourceCode/Images"
     if [[ -d "$test_images_dir" ]]; then
         mkdir -p "$dest_dir"
-        
+
         if [[ -f "$test_images_dir/gs_log_img__log_ball_final_found_ball_img.png" ]]; then
             cp "$test_images_dir/gs_log_img__log_ball_final_found_ball_img.png" \
                "$dest_dir/teed-ball.png"
@@ -260,7 +260,7 @@ install_test_images() {
             cp "$test_images_dir/log_cam2_last_strobed_img.png" \
                "$dest_dir/strobed.png"
         fi
-        
+
         for img in "$test_images_dir"/*.png "$test_images_dir"/*.jpg "$test_images_dir"/*.jpeg; do
             if [[ -f "$img" ]]; then
                 local basename=$(basename "$img")
@@ -270,10 +270,38 @@ install_test_images() {
                 fi
             fi
         done
-        
+
         log_success "Test images installed"
     else
         log_warn "Test images directory not found: $test_images_dir"
+    fi
+}
+
+install_test_suites() {
+    local dest_dir="${1:-/usr/share/pitrac/test-suites}"
+    local repo_root="${2:-${REPO_ROOT:-/opt/PiTrac}}"
+
+    log_info "Installing test suites for automated testing..."
+
+    local testing_dir="$repo_root/Software/LMSourceCode/Testing"
+    if [[ -d "$testing_dir" ]]; then
+        mkdir -p "$dest_dir"
+
+        if [[ -d "$testing_dir/TestSuite_2025_02_07" ]]; then
+            log_info "  Copying TestSuite_2025_02_07..."
+            cp -r "$testing_dir/TestSuite_2025_02_07" "$dest_dir/"
+            log_success "  TestSuite_2025_02_07 installed"
+        fi
+
+        if [[ -d "$testing_dir/Left-Handed-Shots" ]]; then
+            log_info "  Copying Left-Handed-Shots test suite..."
+            cp -r "$testing_dir/Left-Handed-Shots" "$dest_dir/"
+            log_success "  Left-Handed-Shots test suite installed"
+        fi
+
+        log_success "Test suites installed to $dest_dir"
+    else
+        log_warn "Testing directory not found: $testing_dir"
     fi
 }
 
@@ -384,7 +412,7 @@ create_pitrac_directories() {
     log_info "Creating PiTrac directories..."
     
     mkdir -p /usr/lib/pitrac
-    mkdir -p /usr/share/pitrac/{templates,test-images,calibration,webapp}
+    mkdir -p /usr/share/pitrac/{templates,test-images,test-suites,calibration,webapp}
     mkdir -p /var/lib/pitrac
     mkdir -p /etc/pitrac
     


### PR DESCRIPTION
## Description
This PR fixes a couple pathing issues that were causing issues

### What does this PR do?
- Fixes ONNX Pathing
- Fixes Base Image Logging Path issue
- Fixes Test Suite path issues + Defaults

### Why is this change needed?
- OpenCV cannot parse ~/ so it could not load model
- Base image logging path was passed via json but its expected in cli
- Test suite path defaults had windows paths and deprecated paths so would fail
