### PR TITLE
expand all cli paths

### DIFF
--- a/Software/web-server/configurations.json
+++ b/Software/web-server/configurations.json
@@ -32,21 +32,6 @@
       "requiresRestart": true,
       "internal": true
     },
-    "configFile": {
-      "displayName": "Configuration File",
-      "description": "Main configuration file path",
-      "type": "path",
-      "default": "/etc/pitrac/golf_sim_config.json",
-      "requiresRestart": true,
-      "internal": true
-    },
-    "systemConfigPath": {
-      "displayName": "System Config Path",
-      "description": "System-wide configuration file",
-      "type": "path",
-      "default": "/etc/pitrac/golf_sim_config.json",
-      "internal": true
-    },
     "userSettingsPath": {
       "displayName": "User Settings Path",
       "description": "User-specific configuration overrides",

--- a/Software/web-server/pitrac_manager.py
+++ b/Software/web-server/pitrac_manager.py
@@ -30,7 +30,6 @@ class PiTracProcessManager:
             return Path(path_str.replace("~", str(Path.home())))
 
         self.pitrac_binary = sys_paths.get("pitracBinary", {}).get("default", "/usr/lib/pitrac/pitrac_lm")
-        self.config_file = sys_paths.get("configFile", {}).get("default", "/etc/pitrac/golf_sim_config.json")
 
         log_dir = expand_path(sys_paths.get("logDirectory", {}).get("default", "~/.pitrac/logs"))
         pid_dir = expand_path(sys_paths.get("pidDirectory", {}).get("default", "~/.pitrac/run"))
@@ -108,6 +107,8 @@ class PiTracProcessManager:
                 if value:
                     args.append(cli_arg)
             else:
+                if param_type == "path" and value:
+                    value = str(value).replace("~", str(Path.home()))
                 # Use --key=value format for consistency
                 args.append(f"{cli_arg}={value}")
 
@@ -643,7 +644,7 @@ class PiTracProcessManager:
             "is_dual_camera": is_single_pi,  # Single Pi with dual cameras
             "camera1_log_file": str(self.log_file),
             "camera2_log_file": str(self.camera2_log_file),
-            "config_file": self.config_file,
+            "generated_config_path": str(Path.home() / ".pitrac/config/generated_golf_sim_config.json"),
             "binary": self.pitrac_binary,
             "mode": system_mode,
         }

--- a/Software/web-server/tests/test_api_endpoints_pitrac.py
+++ b/Software/web-server/tests/test_api_endpoints_pitrac.py
@@ -100,7 +100,7 @@ class TestPiTracAPIEndpoints:
                 "camera1_pid": 12345,
                 "camera2_pid": None,
                 "mode": "single",
-                "config_file": "/etc/pitrac/golf_sim_config.json",
+                "generated_config_path": "/home/test/.pitrac/config/generated_golf_sim_config.json",
             }
         )
 
@@ -120,7 +120,7 @@ class TestPiTracAPIEndpoints:
                 "camera1_pid": None,
                 "camera2_pid": None,
                 "mode": "single",
-                "config_file": "/etc/pitrac/golf_sim_config.json",
+                "generated_config_path": "/home/test/.pitrac/config/generated_golf_sim_config.json",
             }
         )
 
@@ -139,7 +139,7 @@ class TestPiTracAPIEndpoints:
                 "camera1_pid": 12345,
                 "camera2_pid": 12346,
                 "mode": "dual",
-                "config_file": "/etc/pitrac/golf_sim_config.json",
+                "generated_config_path": "/home/test/.pitrac/config/generated_golf_sim_config.json",
             }
         )
 

--- a/Software/web-server/tests/test_pitrac_manager.py
+++ b/Software/web-server/tests/test_pitrac_manager.py
@@ -4,6 +4,7 @@ Comprehensive tests for the PiTrac Process Manager
 
 import signal
 import pytest
+from pathlib import Path
 from unittest.mock import Mock, patch, AsyncMock, mock_open
 
 from pitrac_manager import PiTracProcessManager
@@ -106,7 +107,6 @@ class TestPiTracProcessManager:
             assert manager.process is None
             assert manager.camera2_process is None
             assert manager.pitrac_binary == "/usr/lib/pitrac/pitrac_lm"
-            assert manager.config_file == "/etc/pitrac/golf_sim_config.json"
             assert manager.config_manager == mock_config_manager
 
             assert mock_mkdir.call_count >= 2
@@ -124,7 +124,7 @@ class TestPiTracProcessManager:
     def test_build_command_single_pi_mode(self, manager):
         """Test command building for single Pi mode"""
         with patch("pathlib.Path.exists", return_value=True):
-            cmd = manager._build_command(camera="camera1", config_file_path="/tmp/test_config.json")
+            cmd = manager._build_command(camera="camera1", config_file_path=Path("/tmp/test_config.json"))
 
         assert manager.pitrac_binary in cmd
         assert "--system_mode=camera1" in cmd
@@ -154,7 +154,7 @@ class TestPiTracProcessManager:
             dual_manager = PiTracProcessManager(config_manager=mock_config_manager)
 
         with patch("pathlib.Path.exists", return_value=True):
-            cmd = dual_manager._build_command(config_file_path="/tmp/test_config.json")
+            cmd = dual_manager._build_command(config_file_path=Path("/tmp/test_config.json"))
 
         assert dual_manager.pitrac_binary in cmd
         assert "--system_mode=camera2" in cmd
@@ -175,7 +175,7 @@ class TestPiTracProcessManager:
     def test_build_command_with_config_file(self, manager):
         """Test command building includes config file"""
         with patch("pathlib.Path.exists", return_value=True):
-            cmd = manager._build_command(camera="camera1", config_file_path="/tmp/test_config.json")
+            cmd = manager._build_command(camera="camera1", config_file_path=Path("/tmp/test_config.json"))
 
         assert "--config_file=/tmp/test_config.json" in cmd
 


### PR DESCRIPTION
## Description
Build on my last PR and expand all CLI Paths as well

### What does this PR do?
Removes the potential for problematic `~/` being passed to pitrac_lm

### Why is this change needed?
- Further increase stability